### PR TITLE
Use getent rather than dig for hostname resolution

### DIFF
--- a/install
+++ b/install
@@ -3,9 +3,11 @@ set -eo pipefail; [[ $PLUSHU_TRACE ]] && set -x
 
 hostname=`hostname -f`
 
-if [[ ! -f "$PLUSHU_ROOT/APPS_DOMAIN" && -n `dig +short "$hostname"` ]]; then
+if [[ ! -f "$PLUSHU_ROOT/APPS_DOMAIN" ]] &&
+  getent hosts "$hostname" >/dev/null; then
+
   echo "Hostname is world-routable, configuring as apps domain..."
-  echo "$hostname" >"$PLUSHU_ROOT/APPS_DOMAIN"
+  printf '%s\n' "$hostname" >"$PLUSHU_ROOT/APPS_DOMAIN"
 else
   echo "To configure a domain to make all app names available under, set it"
   echo "in $PLUSHU_ROOT/APPS_DOMAIN and it will be used when configuring"


### PR DESCRIPTION
`dig` may not be installed on a host system, but `getent` is a core command.

(Maybe) fixes #2
